### PR TITLE
Change the controller repository

### DIFF
--- a/content/tocs/devguides/fetched_files.yml
+++ b/content/tocs/devguides/fetched_files.yml
@@ -160,7 +160,7 @@ repositories:
         - source: CIAT/training/How_to_write_your_own_tests_for_AGL.pdf
         - source: CIAT/training/Hands_on_lab_documentation.pdf
 -
-    git_name: apps/app-controller-submodule
+    git_name: src/libappcontroller
     src_prefix: docs
     dst_prefix: ctrler
     documents:


### PR DESCRIPTION
Change the controller repository to fit the new usage of a library
instead of the git submodule.

Change-Id: Id5766d4ec1321b2552ffa91a52ef8724f0ed648e
Signed-off-by: Romain Forlot <romain.forlot@iot.bzh>