### PR TITLE
Fixes SPEC-2317. Updates screen widths, hides search when needed

### DIFF
--- a/site/static/styles/scss/bootstrap/_navbar.scss
+++ b/site/static/styles/scss/bootstrap/_navbar.scss
@@ -60,6 +60,8 @@
     overflow-y: auto;
   }
 
+  .nav_bar_right { display: none; }
+
   @media (min-width: $grid-float-breakpoint) {
     width: auto;
     border-top: 0;
@@ -75,6 +77,10 @@
     &.in {
       overflow-y: visible;
     }
+
+  @media (min-width: $screen-lg-min) {
+      .nav_bar_right { display: block; }
+  }
 
     // Undo the collapse side padding for navbars with containers to ensure
     // alignment of right-aligned contents.

--- a/site/static/styles/scss/bootstrap/_variables.scss
+++ b/site/static/styles/scss/bootstrap/_variables.scss
@@ -297,21 +297,21 @@ $screen-phone:               $screen-xs-min !default;
 
 // Small screen / tablet
 //** Deprecated `$screen-sm` as of v3.0.1
-$screen-sm:                  768px !default;
+$screen-sm:                  1056px !default;
 $screen-sm-min:              $screen-sm !default;
 //** Deprecated `$screen-tablet` as of v3.0.1
 $screen-tablet:              $screen-sm-min !default;
 
 // Medium screen / desktop
 //** Deprecated `$screen-md` as of v3.0.1
-$screen-md:                  992px !default;
+$screen-md:                  1056px !default;
 $screen-md-min:              $screen-md !default;
 //** Deprecated `$screen-desktop` as of v3.0.1
 $screen-desktop:             $screen-md-min !default;
 
 // Large screen / wide desktop
 //** Deprecated `$screen-lg` as of v3.0.1
-$screen-lg:                  1200px !default;
+$screen-lg:                  1371px !default;
 $screen-lg-min:              $screen-lg !default;
 //** Deprecated `$screen-lg-desktop` as of v3.0.1
 $screen-lg-desktop:          $screen-lg-min !default;


### PR DESCRIPTION
Changes:
Focuses on making the content on smaller screens as usable as possible. Particularly for users that will be stuck on windowed virtual machines for example. The layout changes should work on mobile, tablet, small screens and large displays.

It uses the mobile/tablet layout until the screen is wide enough (too wide?) to display all the header content in one line. 
The search disappears when the screen is not wide enough (effectively the same behavior as cordova.io). 

Issue explanation:
Root cause: There is too much content in the header of http://docs.automotivelinux.org/ for the theme (based on bootstrap). It was previously modified to accommodate some AGL specific changes. 

The scss is half compiled, probably due to these manual changes. This commit is the least intrusive I could think of to make the content readable on all screen sizes.

All buttons and dropdowns/menus are visible and usable across screens. 