### PR TITLE
Fix links to baylibre pdf docs on github

### DIFF
--- a/content/tocs/devguides/section_flounder.yml
+++ b/content/tocs/devguides/section_flounder.yml
@@ -54,12 +54,12 @@ books:
     books:
     -
         id: how-to-write-test-1
-        path: https://github.com/BayLibre/agl-docs-baylibre/blob/%commit%/CIAT/training/How_to_write_your_own_tests_for_AGL.pdf
+        path: https://raw.githubusercontent.com/BayLibre/agl-docs-baylibre/master/CIAT/training/How_to_write_your_own_tests_for_AGL.pdf
         git_commit: master
         name: How to write tests (overview slides)
     -
         id: how-to-write-test-2
-        path: https://github.com/BayLibre/agl-docs-baylibre/blob/%commit%/CIAT/training/Hands_on_lab_documentation.pdf
+        path: https://raw.githubusercontent.com/BayLibre/agl-docs-baylibre/master/CIAT/training/Hands_on_lab_documentation.pdf
         git_commit: master
         name: How to write tests (detailed)
 

--- a/content/tocs/devguides/section_guppy.yml
+++ b/content/tocs/devguides/section_guppy.yml
@@ -60,10 +60,10 @@ books:
     -
         id: how-to-write-test-1
         git_commit: master
-        path: https://github.com/BayLibre/agl-docs-baylibre/blob/%commit%/CIAT/training/How_to_write_your_own_tests_for_AGL.pdf
+        path: https://raw.githubusercontent.com/BayLibre/agl-docs-baylibre/master/CIAT/training/How_to_write_your_own_tests_for_AGL.pdf
         name: How to write tests (overview slides)
     -
         id: how-to-write-test-2
         git_commit: master
-        path: https://github.com/BayLibre/agl-docs-baylibre/blob/%commit%/CIAT/training/Hands_on_lab_documentation.pdf
+        path: https://raw.githubusercontent.com/BayLibre/agl-docs-baylibre/master/CIAT/training/Hands_on_lab_documentation.pdf
         name: How to write tests (detailed)

--- a/content/tocs/devguides/section_master.yml
+++ b/content/tocs/devguides/section_master.yml
@@ -58,9 +58,9 @@ books:
     books:
     -
         id: how-to-write-test-1
-        path: https://github.com/BayLibre/agl-docs-baylibre/blob/%commit%/CIAT/training/How_to_write_your_own_tests_for_AGL.pdf
+        path: https://raw.githubusercontent.com/BayLibre/agl-docs-baylibre/master/CIAT/training/How_to_write_your_own_tests_for_AGL.pdf
         name: How to write tests (overview slides)
     -
         id: how-to-write-test-2
-        path: https://github.com/BayLibre/agl-docs-baylibre/blob/%commit%/CIAT/training/Hands_on_lab_documentation.pdf
+        path: https://raw.githubusercontent.com/BayLibre/agl-docs-baylibre/master/CIAT/training/Hands_on_lab_documentation.pdf
         name: How to write tests (detailed)


### PR DESCRIPTION
We need the proper URL to download the raw files.

Signed-off-by: build.automotivelinux.org <jenkins@automotivelinux.org>