### PR TITLE
contribute: Fix AGL docs link

### DIFF
--- a/site/_data/contribute-repo-links.yml
+++ b/site/_data/contribute-repo-links.yml
@@ -9,7 +9,7 @@
     -   project: AGL-repo
         gerrit: https://gerrit.automotivelinux.org/gerrit/#/admin/projects/AGL/AGL-repo
     -   project: Docs AGL
-        mirror: https://github.com/automotive-grade-linux/docs-agl
+        mirror: https://github.com/automotive-grade-linux/docs-sources
 
 -   title: AGL-Extra
     projects:


### PR DESCRIPTION
The "Docs AGL" link on the contribute page was pointing at an obsolete
GitHub repository.

Bug-AGL: SPEC-2388

Signed-off-by: Paul Barker <pbarker@konsulko.com>