### PR TITLE
Remove old audio documentation on icefish and master

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -6,6 +6,7 @@ conf/_release.yml
 site/_data/all-pages.yml
 site/_data/tocs
 site/_data/docs-versions.yml
+site/.jekyll-cache/
 .fetch.ts
 .LocalFetch.ts
 doctools

--- a/content/tocs/apis_services/section_icefish.yml
+++ b/content/tocs/apis_services/section_icefish.yml
@@ -76,15 +76,6 @@ books:
     git_name: automotive-grade-linux/docs-sources
     path: docs/audio-book.yml
     dst_prefix: audio
-    books:
-        - id: pulseaudio-module-4a-developer-guides
-          git_name: src/pulseaudio-module-4a
-          path: api-services-book.yml
-          dst_prefix: audio
-        - id: agl-service-audio-4a-developer-guides
-          git_name: apps/agl-service-audio-4a
-          path: docs/api-services-book.yml
-          dst_prefix: audio
 -
     id: hmi-framework
     url_fetch: GITHUB_FETCH

--- a/content/tocs/apis_services/section_master.yml
+++ b/content/tocs/apis_services/section_master.yml
@@ -76,15 +76,6 @@ books:
     git_name: automotive-grade-linux/docs-sources
     path: docs/audio-book.yml
     dst_prefix: audio
-    books:
-        - id: pulseaudio-module-4a-developer-guides
-          git_name: src/pulseaudio-module-4a
-          path: api-services-book.yml
-          dst_prefix: audio
-        - id: agl-service-audio-4a-developer-guides
-          git_name: apps/agl-service-audio-4a
-          path: docs/api-services-book.yml
-          dst_prefix: audio
 -
     id: hmi-framework
     url_fetch: GITHUB_FETCH


### PR DESCRIPTION
This no longer applies to icefish and master.

Signed-off-by: Jan-Simon Moeller <jsmoeller@linuxfoundation.org>